### PR TITLE
Initial standalone RabbitMQ implementation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,15 @@
+RABBITMQ_VERSION: 3.6.6-1
+
+RABBITMQ_ADMIN_USERNAME: admin
+RABBITMQ_ADMIN_PASSWORD: changeme
+
+RABBITMQ_TLS_PORT: 5671
+RABBITMQ_HTTPS_PORT: 15671
+
+RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/chain.pem"
+RABBITMQ_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem"
+RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem"
+
+RABBITMQ_APT_PACKAGES:
+  - python-software-properties
+  - python-letsencrypt

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart rabbitmq
+  service:
+    name: rabbitmq-server
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,89 @@
+- name: install apt packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ RABBITMQ_APT_PACKAGES }}"
+
+- name: Open RabbitMQ firewall ports
+  ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  with_items:
+    - 5671
+    - 15671
+    - 80
+
+- name: generate certificate for domain
+  command: "letsencrypt certonly --email ops@opencraft.com --authenticator standalone --standalone-supported-challenges http-01 --http-01-port 80 --non-interactive --agree-tos --keep --expand -d {{ ansible_fqdn }}"
+  args:
+    creates: "/etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem"
+
+- name: set up cron job for certificate renewal
+  cron:
+    name: "Renew SSL certificate using the letsencrypt client"
+    job: letsencrypt renew --standalone-supported-challenges http-01 --http-01-port 80
+    hour: "*/12"
+    minute: "?"
+    cron_file: letsencrypt-renew
+    user: root
+
+- name: add rabbitmq repository
+  apt_repository:
+    repo: 'deb https://www.rabbitmq.com/debian/ testing main'
+    state: present
+
+- name: add rabbitmq trusted key
+  apt_key:
+    url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+    state: present
+
+- name: install rabbitmq
+  apt:
+    name: "rabbitmq-server={{ RABBITMQ_VERSION }}"
+    update_cache: yes
+    state: installed
+
+- name: set letsencrypt directory owner
+  file:
+    path: "/etc/letsencrypt/{{ item }}"
+    owner: rabbitmq
+    state: directory
+  with_items:
+    - live
+    - archive
+
+- name: write rabbitmq configuration
+  template:
+    src: rabbitmq.config.j2
+    dest: /etc/rabbitmq/rabbitmq.config
+  notify:
+    - restart rabbitmq
+
+- name: enable rabbitmq plugins
+  rabbitmq_plugin:
+    names: rabbitmq_management,rabbitmq_tracing,rabbitmq_federation
+    state: enabled
+  notify:
+    - restart rabbitmq
+
+- name: create default admin user
+  rabbitmq_user:
+    user: "{{ RABBITMQ_ADMIN_USERNAME }}"
+    tags: "administrator,{{ RABBITMQ_ADMIN_USERNAME }}"
+    password: "{{ RABBITMQ_ADMIN_PASSWORD }}"
+    vhost: /
+    configure_priv: .*
+    write_priv: .*
+    read_priv: .*
+    state: present
+
+- name: remove default guest user
+  rabbitmq_user:
+    user: guest
+    state: absent
+
+- name: ensure vhost /test is present
+  rabbitmq_vhost:
+    name: /test
+    state: present

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -1,0 +1,21 @@
+[
+ %% Disable SSLv3.0 (POODLE) and TLSv1.0 (BEAST) support.
+ {ssl, [{versions, ['tlsv1.2', 'tlsv1.1']}]},
+ {rabbit, [
+           {ssl_listeners, [{{ RABBITMQ_TLS_PORT}}]},
+           {ssl_options, [{cacertfile,"{{ RABBITMQ_CA_CERTIFICATE_FILE }}"},
+                          {certfile,  "{{ RABBITMQ_CERTIFICATE_FILE }}"},
+                          {keyfile,   "{{ RABBITMQ_KEY_FILE }}"},
+                          {versions, ['tlsv1.2', 'tlsv1.1']}
+                         ]}
+          ]},
+ {rabbitmq_management, [
+                        {listener, [{port,     {{ RABBITMQ_HTTPS_PORT }}},
+                                    {ssl,      true},
+                                    {ssl_opts, [{cacertfile, "{{ RABBITMQ_CA_CERTIFICATE_FILE }}"},
+                                                {certfile,   "{{ RABBITMQ_CERTIFICATE_FILE }}"},
+                                                {keyfile,    "{{ RABBITMQ_KEY_FILE }}"}
+                                               ]}
+                                   ]}
+                       ]}
+].


### PR DESCRIPTION
This PR implements a simple Ansible role to setup a non-clustered standalone RabbitMQ. This was adapted from the ansible-examples repo.

This playbook is already deployed on rabbitmq-dev.opencraft.hosting, rabbitmq-stage.opencraft.hosting, and rabbitmq.opencraft.hosting.

**Testing instructions:**

1. Clone [`deployment-secret-services`](https://github.com/open-craft/deployment-secrets-services) and checkout the [`bdero/rabbitmq`](https://github.com/open-craft/deployment-secrets-services/pull/13) branch.
1. Setup `deployment-secret-services` using the [readme instructions](https://github.com/open-craft/deployment-secrets-services#preparatory-steps).
1. In the **hosts** file, comment out the `rabbitmq.opencraft.hosting` and `rabbitmq-stage.opencraft.hosting` lines.
1. Run the playbook over **rabbitmq-dev.opencraft.hosting**. Replace `$SHARED_MYSQL_IDENT` with the location of the shared DB key (use the "ssh key for databases instances" entry in keepass):
   ```
   ansible-playbook -vvv deploy/deploy-all.yml -u ubuntu --private-key $SHARED_MYSQL_IDENT -i hosts -l rabbitmq --vault-password-file .vault-pass
   ```