### PR TITLE
Increase file descriptor limit and letsencrypt hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,9 +6,11 @@ RABBITMQ_ADMIN_PASSWORD: changeme
 RABBITMQ_TLS_PORT: 5671
 RABBITMQ_HTTPS_PORT: 15671
 
-RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/chain.pem"
-RABBITMQ_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem"
-RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem"
+RABBITMQ_HOSTNAME: "{{ inventory_hostname }}"
+
+RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/chain.pem"
+RABBITMQ_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/cert.pem"
+RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/privkey.pem"
 
 RABBITMQ_APT_PACKAGES:
   - python-software-properties

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
+- name: reload systemd
+  command: systemctl daemon-reload
+
 - name: restart rabbitmq
   service:
     name: rabbitmq-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,9 @@
     - 80
 
 - name: generate certificate for domain
-  command: "letsencrypt certonly --email ops@opencraft.com --authenticator standalone --standalone-supported-challenges http-01 --http-01-port 80 --non-interactive --agree-tos --keep --expand -d {{ ansible_fqdn }}"
+  command: "letsencrypt certonly --email ops@opencraft.com --authenticator standalone --standalone-supported-challenges http-01 --http-01-port 80 --non-interactive --agree-tos --keep --expand -d {{ RABBITMQ_HOSTNAME }}"
   args:
-    creates: "/etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem"
+    creates: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/cert.pem"
 
 - name: set up cron job for certificate renewal
   cron:
@@ -43,6 +43,22 @@
     name: "rabbitmq-server={{ RABBITMQ_VERSION }}"
     update_cache: yes
     state: installed
+
+- name: Set the file descriptor limit to a high value in the systemd service
+  ini_file:
+    dest: /lib/systemd/system/rabbitmq-server.service
+    section: Service
+    option: "{{ item }}"
+    value: 65535
+    backup: yes
+  with_items:
+    - LimitNOFILE
+    - LimitNPROC
+  notify:
+    - reload systemd
+    - restart rabbitmq
+  tags:
+    - fd_limit
 
 - name: set letsencrypt directory owner
   file:


### PR DESCRIPTION
This change adds tasks to insert the following lines below the systemd service definition:
```
LimitNOFILE=65535
LimitNPROC=65535
```

Also, instead of using `ansible_fqdn` to determine the letsencrypt hostname, use `inventory_hostname`, which is far more predictable if there are multiple domains which resolve to the host IP.