### PR TITLE
Add scripts and a cron to export/import RabbitMQ definitions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,9 @@ RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/privkey.pem"
 RABBITMQ_APT_PACKAGES:
   - python-software-properties
   - python-letsencrypt
+
+RABBITMQ_EXPORT_DIR: /usr/local/lib/rabbitmq/backup
+RABBITMQ_SCRIPTS_DIR: /usr/local/bin
+
+RABBITMQ_BACKUP_COMMAND: rabbitmq-backup
+RABBITMQ_RESTORE_COMMAND: rabbitmq-restore

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,8 @@ RABBITMQ_APT_PACKAGES:
   - python-software-properties
   - python-letsencrypt
 
-RABBITMQ_EXPORT_DIR: /usr/local/lib/rabbitmq/backup
-RABBITMQ_SCRIPTS_DIR: /usr/local/bin
+RABBITMQ_EXPORT_DIR: /var/local/rabbitmq/backup
+RABBITMQ_SCRIPTS_DIR: /usr/local/sbin
 
 RABBITMQ_BACKUP_COMMAND: rabbitmq-backup
 RABBITMQ_RESTORE_COMMAND: rabbitmq-restore

--- a/files/rabbitmq-backup
+++ b/files/rabbitmq-backup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DEST="$1"
+python /var/lib/rabbitmq/mnesia/*plugins-expand/rabbitmq_management-*/priv/www/cli/rabbitmqadmin export $DEST -c /etc/rabbitmqadmin.conf -N host_ssl -q

--- a/files/rabbitmq-backup
+++ b/files/rabbitmq-backup
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DEST="$1"
-python /var/lib/rabbitmq/mnesia/*plugins-expand/rabbitmq_management-*/priv/www/cli/rabbitmqadmin export $DEST -c /etc/rabbitmqadmin.conf -N host_ssl -q
+python {{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin export $DEST -c /etc/rabbitmqadmin.conf -N host_ssl

--- a/files/rabbitmq-restore
+++ b/files/rabbitmq-restore
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SRC="$1"
+python /var/lib/rabbitmq/mnesia/*plugins-expand/rabbitmq_management-*/priv/www/cli/rabbitmqadmin import $SRC -c /etc/rabbitmqadmin.conf -N host_ssl

--- a/files/rabbitmq-restore
+++ b/files/rabbitmq-restore
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-SRC="$1"
-python /var/lib/rabbitmq/mnesia/*plugins-expand/rabbitmq_management-*/priv/www/cli/rabbitmqadmin import $SRC -c /etc/rabbitmqadmin.conf -N host_ssl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,8 +69,8 @@
     mode: 600
 
 - name: add rabbitmq import/export scripts
-  copy:
-    src: "{{ item }}"
+  template:
+    src: "{{ item }}.j2"
     dest: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ item }}"
     owner: root
     group: root
@@ -86,14 +86,6 @@
     owner: root
     group: root
     mode: 700
-
-- name: set up cron job for rabbitmq exporting
-  cron:
-    name: "Export RabbitMQ definitions for backup"
-    job: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ RABBITMQ_BACKUP_COMMAND }} {{ RABBITMQ_EXPORT_DIR }}/rabbitmq.definitions.json"
-    minute: 0
-    cron_file: rabbitmq-backup
-    user: root
 
 - name: set letsencrypt directory owner
   file:
@@ -128,6 +120,19 @@
     write_priv: .*
     read_priv: .*
     state: present
+
+# RabbitMQ must be restarted after installing the rabbitmq_management plugin in order to use the
+# HTTP API, and we need the HTTP API to fetch the rabbitmqadmin tool, so the handlers are flushed here.
+- meta: flush_handlers
+
+- name: fetch the rabbitmqadmin script from the management webserver
+  get_url:
+    url: "https://{{ RABBITMQ_HOSTNAME }}:{{ RABBITMQ_HTTPS_PORT }}/cli/rabbitmqadmin"
+    dest: "{{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin"
+    checksum: md5:51eb3e163c884bc1b079aafdf71d0d3b
+    owner: root
+    group: root
+    mode: 700
 
 - name: remove default guest user
   rabbitmq_user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,41 @@
   tags:
     - fd_limit
 
+- name: add rabbitmqadmin config
+  template:
+    src: rabbitmqadmin.conf.j2
+    dest: /etc/rabbitmqadmin.conf
+    owner: root
+    group: root
+    mode: 600
+
+- name: add rabbitmq import/export scripts
+  copy:
+    src: "{{ item }}"
+    dest: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ item }}"
+    owner: root
+    group: root
+    mode: 700
+  with_items:
+    - "{{ RABBITMQ_BACKUP_COMMAND }}"
+    - "{{ RABBITMQ_RESTORE_COMMAND }}"
+
+- name: add rabbitmq export directory
+  file:
+    path: "{{ RABBITMQ_EXPORT_DIR }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 700
+
+- name: set up cron job for rabbitmq exporting
+  cron:
+    name: "Export RabbitMQ definitions for backup"
+    job: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ RABBITMQ_BACKUP_COMMAND }} {{ RABBITMQ_EXPORT_DIR }}/rabbitmq.definitions.json"
+    minute: 0
+    cron_file: rabbitmq-backup
+    user: root
+
 - name: set letsencrypt directory owner
   file:
     path: "/etc/letsencrypt/{{ item }}"

--- a/templates/rabbitmq-backup.j2
+++ b/templates/rabbitmq-backup.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python {{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin export {{ RABBITMQ_EXPORT_DIR }}/rabbitmq.definitions.json -c /etc/rabbitmqadmin.conf -N host_ssl -q

--- a/templates/rabbitmq-restore.j2
+++ b/templates/rabbitmq-restore.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SRC="$1"
+python {{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin import $SRC -c /etc/rabbitmqadmin.conf -N host_ssl

--- a/templates/rabbitmqadmin.conf.j2
+++ b/templates/rabbitmqadmin.conf.j2
@@ -1,0 +1,6 @@
+[host_ssl]
+hostname = {{ RABBITMQ_HOSTNAME }}
+port = {{ RABBITMQ_HTTPS_PORT }}
+ssl = True
+username = {{ RABBITMQ_ADMIN_USERNAME }}
+password = {{ RABBITMQ_ADMIN_PASSWORD }}


### PR DESCRIPTION
This PR adds a script and cron for exporting RabbitMQ definitions to a given location. It also adds a script for importing RabbitMQ definitions restored from backup. CC @smarnach 