### PR TITLE
 Add package holding and use override directory to set file descriptor limit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,8 +17,8 @@ ERLANG_REPO_KEY: "http://packages.erlang-solutions.com/debian/erlang_solutions.a
 RABBITMQ_REPO: "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_distribution_release }} main"
 RABBITMQ_REPO_KEY: "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
 
-ERLANG_VERSION: 1:20.0-1
-RABBITMQ_VERSION: 3.6.11-1
+ERLANG_VERSION: 1:20.1-1
+RABBITMQ_VERSION: 3.6.14-1
 
 RABBITMQ_APT_PACKAGES:
   - apt-transport-https

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,8 @@
   with_items:
     - "{{ ERLANG_REPO }}"
     - "{{ RABBITMQ_REPO }}"
+  tags:
+    - install_rabbitmq
 
 - name: add trusted repository keys
   apt_key:
@@ -43,6 +45,19 @@
   with_items:
     - "{{ ERLANG_REPO_KEY }}"
     - "{{ RABBITMQ_REPO_KEY }}"
+  tags:
+    - install_rabbitmq
+
+- name: Unlock erlang and rabbitmq
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  with_items:
+    - erlang-nox
+    - rabbitmq-server
+  ignore_errors: yes
+  tags:
+    - install_rabbitmq
 
 - name: install rabbitmq
   apt:
@@ -53,14 +68,38 @@
   with_items:
     - "erlang-nox={{ ERLANG_VERSION }}"
     - "rabbitmq-server={{ RABBITMQ_VERSION }}"
+  tags:
+    - install_rabbitmq
+
+- name: Lock erlang and rabbitmq
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  with_items:
+    - erlang-nox
+    - rabbitmq-server
+  tags:
+    - install_rabbitmq
+
+- name: Create directory for RabbitMQ service overrides
+  file:
+    path: /etc/systemd/system/rabbitmq-server.service.d/
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  tags:
+    - fd_limit
 
 - name: Set the file descriptor limit to a high value in the systemd service
   ini_file:
-    dest: /lib/systemd/system/rabbitmq-server.service
+    dest: /etc/systemd/system/rabbitmq-server.service.d/limits.conf
     section: Service
     option: "{{ item }}"
     value: 65535
-    backup: yes
+    mode: 0644
+    owner: root
+    group: root
   with_items:
     - LimitNOFILE
     - LimitNPROC


### PR DESCRIPTION
JIRA ticket: [OC-3372](https://tasks.opencraft.com/browse/OC-3372)

This change set contains:
- dpkg holding for RabbitMQ and Erlang, because we need to have intentional, tested upgrades of the RabbitMQ - and prevent apt-daily from automatically upgrading it
- Upgrade of RabbitMQ and Erlang to latest version available in the repository, because they were already automatically upgraded to this version on stage/prod
- Usage of an override directory to set the file descriptor limit for rabbitmq-service, rather than patch the service file directory

FYI @smarnach and @mtyaka 

This version has already been deployed to rabbitmq-stage.