### PR TITLE
Set log level to only log warnings or worse

### DIFF
--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -8,6 +8,7 @@
                           {keyfile,   "{{ RABBITMQ_KEY_FILE }}"},
                           {versions, ['tlsv1.2', 'tlsv1.1']}
                          ]},
+           {log_levels, [{connection, warning}]},
            {vm_memory_high_watermark, {{ RABBITMQ_HIGH_MEMORY_ALARM }}}
           ]},
  {rabbitmq_management, [


### PR DESCRIPTION
This increases the log level to warning to prevent the excessive logging of every client connection that was filling the disk.